### PR TITLE
Remove 2nd arg for DeclareGlobalVariable

### DIFF
--- a/gap/latex/digraphs.gd
+++ b/gap/latex/digraphs.gd
@@ -26,8 +26,7 @@
 #! @Description
 #!   Default command-line options passed to the `dot2tex` executable
 #!   to convert dot strings.
-DeclareGlobalVariable("DEFAULT_DOT2TEX_OPTIONS",
-    "List of default command-line options passed to dot2tex when converting dot snippets.");
+DeclareGlobalVariable("DEFAULT_DOT2TEX_OPTIONS");
 
 #! @Description
 #!   Executes `dot2tex` on the dot string representing a

--- a/gap/latex/render.gd
+++ b/gap/latex/render.gd
@@ -73,18 +73,15 @@ DeclareGlobalFunction("NeedsLatexMathMode");
 #! @Description
 #!   Default LaTeX preamble string used for creating
 #!   compilable `.tex` files from LaTeX snippets.
-DeclareGlobalVariable("DEFAULT_LATEX_PREAMBLE",
-    "Default LaTeX preamble used for creating compilable TeX files from snippets.");
+DeclareGlobalVariable("DEFAULT_LATEX_PREAMBLE");
 
 #! @Description
 #!   Default HTML document and head tags used to create
 #!   HTML files using MathJax to render LaTeX snippets.
-DeclareGlobalVariable("DEFAULT_MATHJAX_TAGS",
-    "Default HTML document and head tags used to create HTML files using MathJax to render LaTeX snippets.");
+DeclareGlobalVariable("DEFAULT_MATHJAX_TAGS");
 
 #! @Description
 #!   String containing all of the characters that do not
 #!   need to be percent-encoded within URI components,
 #!   as per RFC-3986.
-DeclareGlobalVariable("ALWAYS_UNESCAPED_CHARS",
-    "Reserved characters in URIs that do not need to be percent encoded.");
+DeclareGlobalVariable("ALWAYS_UNESCAPED_CHARS");

--- a/gap/typeset.gd
+++ b/gap/typeset.gd
@@ -133,5 +133,4 @@ DeclareGlobalFunction("MergeSubOptions");
 #!   Default options record passed to <Ref Func="Typeset" />. Merged with user-provided
 #!   options to ensure correct construction of options for sub-calls,
 #!   whilst also allowing option-less calls to the method.
-DeclareGlobalVariable("DEFAULT_TYPESET_OPTIONS",
-    "Default options record for the Typeset method.");
+DeclareGlobalVariable("DEFAULT_TYPESET_OPTIONS");


### PR DESCRIPTION
It is ignored by GAP, and the comments above already explain what
the variables are about.
