### PR TITLE
Force-load Test Dependencies

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -7,10 +7,7 @@
 LoadPackage( "ctbllib" );
 LoadPackage( "digraphs" );
 
-# Reread package instead of loading due to digraphs functionality
-# potentially not being loaded.
-RereadPackage( "typeset", "init.g");
-RereadPackage( "typeset", "read.g");
+LoadPackage( "typeset" );
 
 SetInfoLevel(InfoTypeset, 0);
 

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -4,7 +4,13 @@
 # This file runs package tests. It is also referenced in the package
 # metadata in PackageInfo.g.
 #
-LoadPackage( "typeset" );
+LoadPackage( "ctbllib" );
+LoadPackage( "digraphs" );
+
+# Reread package instead of loading due to digraphs functionality
+# potentially not being loaded.
+RereadPackage( "typeset", "init.g");
+RereadPackage( "typeset", "read.g");
 
 SetInfoLevel(InfoTypeset, 0);
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes #29 

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/gap-packages/typeset/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Tests load `ctbllib` and `digraphs` to pass when the OnlyNeeded option is used to load the `typeset` package. Furthermore, as this option may also mean that the initial load of `typeset` (i.e. when a user loads the package with OnlyNeeded prior to running the test suite) , the RereadPackage option was used in lieu of a simple LoadPackage as digraphs functionality is skipped if the `digraphs` package is not marked for loading on the initial load.

This commit was tested both using the GAP console (`gap -A`) with `LoadPackage("typeset":OnlyNeeded); TestPackage("typeset":OnlyNeeded)`, as well as using the test files directly `gap testall.g` to ensure compliance.

### Check off the following:

- [x] I have added the necessary functions to implement my fix in a structured, readable way.
- [x] I have documented my added code to the codebase, added new directories to `makedoc.g` and new chapters/sections to `order_info.g`.
- [x] I have tested my additions, and included the tests within the `tst` directory.
- [x] I have summarised any large features as bullet points in `CHANGELOG.md`.
