### PR TITLE
Delete a test involving Alt(5)

### DIFF
--- a/tst/latex/ctbls.tst
+++ b/tst/latex/ctbls.tst
@@ -31,24 +31,6 @@ X.5 & 1 & 1 & 1 & 1 & 1 \\
 \end{array}
 \end{gather*}
 
-# Alternating Group
-gap> c := CharacterTable(AlternatingGroup(5));;
-gap> Typeset(c);
-\begin{gather*}
-\begin{array}{c c c c c c}
- & 1a & 2a & 3a & 5a & 5b \\
-X.1 & 1 & 1 & 1 & 1 & 1 \\
-X.2 & 3 & -1 & . & A & *A \\
-X.3 & 3 & -1 & . & *A & A \\
-X.4 & 4 & . & 1 & -1 & -1 \\
-X.5 & 5 & 1 & -1 & . & . \\
-\end{array}\\
-\begin{aligned}
-A &= -E(5)-E(5)^4 \\
- &= (1-Sqrt(5))/2 = -b5 \\
-\end{aligned}
-\end{gather*}
-
 # SL Group
 gap> c := CharacterTable(SL(2, 5));;
 gap> Typeset(c);


### PR DESCRIPTION
In GAP master we now use a generic character table for alternating
groups. As a result the content is now ordered differently. Both
versions are correct. To let the tests pass with both old and new
GAP, we just delete it -- there are other tests for this feature
right afterwards, and at least looking at them there seems to be
nothing unique about the test involving the alternating group. So
removing it seems reasonable.

@ZachNewbery it would be good to get this into a release ASAP. If you
are too busy, and are OK with it, then I could also take care of this.
