### PR TITLE
Add 'dot2tex' under ExternalConditions

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -66,7 +66,7 @@ Dependencies := rec(
   GAP := ">= 4.11",
   NeededOtherPackages := [ ],
   SuggestedOtherPackages := [["digraphs", ">=1.5.0"],],
-  ExternalConditions := [ ],
+  ExternalConditions := ["dot2tex (https://dot2tex.readthedocs.io/en/latest/installation_guide.html) must be installed"],
 ),
 
 AvailabilityTest := ReturnTrue,

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -66,7 +66,7 @@ Dependencies := rec(
   GAP := ">= 4.11",
   NeededOtherPackages := [ ],
   SuggestedOtherPackages := [["digraphs", ">=1.5.0"],],
-  ExternalConditions := ["dot2tex (https://dot2tex.readthedocs.io/en/latest/installation_guide.html) must be installed"],
+  ExternalConditions := [["dot2tex must be installed", "https://dot2tex.readthedocs.io/en/latest/installation_guide.html"]],
 ),
 
 AvailabilityTest := ReturnTrue,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/gap-packages/typeset/workflows/CI/badge.svg?branch=main)](https://github.com/gap-packages/typeset/actions?query=workflow%3ACI+branch%3Amain)
+[![CI](https://github.com/gap-packages/typeset/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/gap-packages/typeset/actions/workflows/CI.yml)
 [![Code Coverage](https://codecov.io/github/gap-packages/typeset/coverage.svg?branch=main&token=)](https://codecov.io/gh/gap-packages/typeset)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gap-packages/typeset/HEAD)
 


### PR DESCRIPTION
### Why:

Closes #35 

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adding 'dot2tex' to ExternalConditions so that users are aware of it being required for digraph conversion.

Additionally, fixing CI badge link in README to conform to new format.

### Check off the following:

- [x] I have added the necessary functions to implement my fix in a structured, readable way.
- [x] I have documented my added code to the codebase, added new directories to `makedoc.g` and new chapters/sections to `order_info.g`.
- [x] I have tested my additions, and included the tests within the `tst` directory.
- [x] I have summarised any large features as bullet points in `CHANGELOG.md`.
