### PR TITLE
Update `PackageInfo.g` and CI suite

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,44 +18,51 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }}
+    name: ${{ matrix.gap-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        gap-branch:
-          - master
-          - stable-4.15
-          - stable-4.14
-          - stable-4.13
-          - stable-4.12
+        gap-version:
+          - 'devel'
+          - '4.15'
+          - '4.14'
+          - '4.13'
+          - '4.12'
         pkgs-to-clone: 
-          - datastructures NautyTracesInterface digraphs
+          - |
+            gap-packages/datastructures@devel
+            gap-packages/NautyTracesInterface@devel
+            digraphs/digraphs@devel
 
     steps:
       - name: "Checkout package repository"
         uses: actions/checkout@v6
       - name: "Setup Python"
-        uses: actions/setup-python@v5
-      - name: "Install dot2tex dependencies"
-        run: sudo apt install graphviz texlive preview-latex-style dot2tex
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
       - name: "Setup GAP"
-        uses: gap-actions/setup-gap@v2
+        uses: gap-actions/setup-gap@v3
         with:
-          GAP_PKGS_TO_CLONE: "${{ matrix.pkgs-to-clone }}"
-          GAP_PKGS_TO_BUILD: "io orb profiling grape NautyTracesInterface datastructures digraphs"
-          GAPBRANCH: ${{ matrix.gap-branch }}
+          gap-version: ${{ matrix.gap-version }}
+      - name: "Clone packages"
+        uses: gap-actions/install-pkg@v1
+        with:
+          packages: ${{ matrix.pkgs-to-clone }}
       - name: "Build 'typeset' package"
-        uses: gap-actions/build-pkg@v1
-      - name: "Run 'typeset' package tests"
-        uses: gap-actions/run-pkg-tests@v3
-      - name: "Run 'typeset' package tests (with only needed packages loaded)"
-        uses: gap-actions/run-pkg-tests@v3
+        uses: gap-actions/build-pkg@v3
         with:
-          only-needed: true
+          build-suggested-pkgs: 'recursive' # Also build packages suggested by digraphs
+      - name: "Run 'typeset' package tests"
+        uses: gap-actions/run-pkg-tests@v4
+      - name: "Run 'typeset' package tests (with only needed packages loaded)"
+        uses: gap-actions/run-pkg-tests@v4
+        with:
+          mode: onlyneeded
       - name: "Process test coverage"
-        uses: gap-actions/process-coverage@v2
+        uses: gap-actions/process-coverage@v3
       - name: "Publish code coverage"
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -66,6 +66,7 @@ Dependencies := rec(
   GAP := ">= 4.11",
   NeededOtherPackages := [ ],
   SuggestedOtherPackages := [["digraphs", ">=1.5.0"],],
+  NeededSystemPackages := rec( Ubuntu := [["dot2tex"],  ["preview-latex-style"], ["texlive-pictures"]] ),
   ExternalConditions := [ ],
 ),
 


### PR DESCRIPTION
This PR updates all actions used in the CI workflow to the latest version, and makes use of the new `Dependencies.NeededSystemPackages` field in `PackageInfo.g` to simplify the CI workflow(s).

Remarks:
 - `PackageInfo.g` claims compatibility with GAP 4.11, but does not test this. Is this intended?
 - I changed the dependencies from `graphviz texlive preview-latex-style dot2tex` to `dot2tex preview-latex-style texlive-pictures`. I removed `graphviz` because it is a dependency of `dot2tex` anyway. I added `texlive-pictures` since this was missing (it is only recommended by `dot2tex`, not needed, and in CI tests we often install packages using `--no-install-recommends`). Finally I removed `texlive`, since this doesn't seem to be needed at all.