### PR TITLE
Don't pass package name to AutoDoc()

### DIFF
--- a/makedoc.g
+++ b/makedoc.g
@@ -7,4 +7,9 @@ if fail = LoadPackage("AutoDoc") then
     Error("AutoDoc required.");
 fi;
 
-AutoDoc("typeset", rec( scaffold := true, autodoc := rec( scan_dirs := [ ".", "gap", "lib", "examples", "examples/doc", "gap/latex", "gap/mathml" ] )));
+AutoDoc(rec(
+    scaffold := true,
+    autodoc := rec(
+        scan_dirs := [ ".", "gap", "lib", "examples", "examples/doc", "gap/latex", "gap/mathml" ],
+    ),
+));


### PR DESCRIPTION
This has been deprecated for many years and may be removed
in a future AutoDoc release.
