### PR TITLE
Add maintainers to PackageInfo.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -21,9 +21,29 @@ Persons := [
     WWWHome := "https://zachnewbery.com",
     Email := "me@zachnewbery.com",
     IsAuthor := true,
-    IsMaintainer := true,
-    Place := "St. Andrews",
-    Institution := "University of St. Andrews",
+    IsMaintainer := true
+  ),
+  rec(
+    LastName      := "Konovalov",
+    FirstNames    := "Olexandr",
+    IsAuthor      := false,
+    IsMaintainer  := true,
+    Email         := "obk1@st-andrews.ac.uk",
+    WWWHome       := "https://olexandr-konovalov.github.io/",
+    PostalAddress := Concatenation( [
+                     "School of Computer Science\n",
+                     "University of St Andrews\n",
+                     "Jack Cole Building, North Haugh,\n",
+                     "St Andrews, Fife, KY16 9SX, Scotland" ] ),
+    Place         := "St Andrews",
+    Institution   := "University of St Andrews"
+  ),
+  rec(
+    LastName      := "GAP Team",
+    FirstNames    := "The",
+    IsAuthor      := false,
+    IsMaintainer  := true,
+    Email         := "support@gap-system.org",
   ),
 ],
 


### PR DESCRIPTION
### Why:

Add additional maintainers due to lower capacity from myself.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Added details to PackageInfo.g for additional maintainers.

### Check off the following:

- [x] I have added the necessary functions to implement my fix in a structured, readable way.
- [x] I have documented my added code to the codebase, added new directories to `makedoc.g` and new chapters/sections to `order_info.g`.
- [x] I have tested my additions, and included the tests within the `tst` directory.
- [x] I have summarised any large features as bullet points in `CHANGELOG.md`.
